### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/decoders.py
+++ b/decoders.py
@@ -81,7 +81,7 @@ class BitPackedBuffer:
         return result
 
     def read_unaligned_bytes(self, bytes):
-        return ''.join([chr(self.read_bits(8)) for i in xrange(bytes)])
+        return ''.join([chr(self.read_bits(8)) for i in range(bytes)])
 
 
 class BitPackedDecoder:
@@ -109,7 +109,7 @@ class BitPackedDecoder:
 
     def _array(self, bounds, typeid):
         length = self._int(bounds)
-        return [self.instance(typeid) for i in xrange(length)]
+        return [self.instance(typeid) for i in range(length)]
 
     def _bitarray(self, bounds):
         length = self._int(bounds)
@@ -206,7 +206,7 @@ class VersionedDecoder:
     def _array(self, bounds, typeid):
         self._expect_skip(0)
         length = self._vint()
-        return [self.instance(typeid) for i in xrange(length)]
+        return [self.instance(typeid) for i in range(length)]
 
     def _bitarray(self, bounds):
         self._expect_skip(1)
@@ -259,7 +259,7 @@ class VersionedDecoder:
         self._expect_skip(5)
         result = {}
         length = self._vint()
-        for i in xrange(length):
+        for i in range(length):
             tag = self._vint()
             field = next((f for f in fields if f[2] == tag), None)
             if field:
@@ -281,7 +281,7 @@ class VersionedDecoder:
         skip = self._buffer.read_bits(8)
         if skip == 0:  # array
             length = self._vint()
-            for i in xrange(length):
+            for i in range(length):
                 self._skip_instance()
         elif skip == 1:  # bitblob
             length = self._vint()
@@ -298,7 +298,7 @@ class VersionedDecoder:
                 self._skip_instance()
         elif skip == 5:  # struct
             length = self._vint()
-            for i in xrange(length):
+            for i in range(length):
                 tag = self._vint()
                 self._skip_instance()
         elif skip == 6:  # u8

--- a/heroprotocol.py
+++ b/heroprotocol.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import print_function
 import sys
 import argparse
 import pprint
@@ -48,7 +49,7 @@ class EventLogger:
 
     def log_stats(self, output):
         for name, stat in sorted(self._event_stats.iteritems(), key=lambda x: x[1][1]):
-            print >> output, '"%s", %d, %d,' % (name, stat[0], stat[1] / 8)
+            print('"%s", %d, %d,' % (name, stat[0], stat[1] / 8), file=output)
 
 
 if __name__ == '__main__':
@@ -90,7 +91,7 @@ if __name__ == '__main__':
     try:
         protocol = __import__('protocol%s' % (baseBuild,))
     except:
-        print >> sys.stderr, 'Unsupported base build: %d' % baseBuild
+        print('Unsupported base build: %d' % baseBuild, file=sys.stderr)
         sys.exit(1)
 
     # Print protocol details

--- a/mpyq/mpyq.py
+++ b/mpyq/mpyq.py
@@ -4,6 +4,7 @@
 """
 mpyq is a Python library for reading MPQ (MoPaQ) archives.
 """
+from __future__ import print_function
 
 import bz2
 import cStringIO
@@ -263,47 +264,47 @@ class MPQArchive(object):
             f.close()
 
     def print_headers(self):
-        print "MPQ archive header"
-        print "------------------"
+        print("MPQ archive header")
+        print("------------------")
         for key, value in self.header.iteritems():
             if key == "user_data_header":
                 continue
-            print "{0:30} {1!r}".format(key, value)
+            print("{0:30} {1!r}".format(key, value))
         if self.header.get('user_data_header'):
-            print
-            print "MPQ user data header"
-            print "--------------------"
+            print()
+            print("MPQ user data header")
+            print("--------------------")
             for key, value in self.header['user_data_header'].iteritems():
-                print "{0:30} {1!r}".format(key, value)
-        print
+                print("{0:30} {1!r}".format(key, value))
+        print()
 
     def print_hash_table(self):
-        print "MPQ archive hash table"
-        print "----------------------"
-        print " Hash A   Hash B  Locl Plat BlockIdx"
+        print("MPQ archive hash table")
+        print("----------------------")
+        print(" Hash A   Hash B  Locl Plat BlockIdx")
         for entry in self.hash_table:
-            print '%08X %08X %04X %04X %08X' % entry
-        print
+            print('%08X %08X %04X %04X %08X' % entry)
+        print()
 
     def print_block_table(self):
-        print "MPQ archive block table"
-        print "-----------------------"
-        print " Offset  ArchSize RealSize  Flags"
+        print("MPQ archive block table")
+        print("-----------------------")
+        print(" Offset  ArchSize RealSize  Flags")
         for entry in self.block_table:
-            print '%08X %8d %8d %8X' % entry
-        print
+            print('%08X %8d %8d %8X' % entry)
+        print()
 
     def print_files(self):
         if self.files:
-            print "Files"
-            print "-----"
+            print("Files")
+            print("-----")
             width = max(len(name) for name in self.files) + 2
             for filename in self.files:
                 hash_entry = self.get_hash_table_entry(filename)
                 block_entry = self.block_table[hash_entry.block_table_index]
-                print "{0:{width}} {1:>8} bytes".format(filename,
+                print("{0:{width}} {1:>8} bytes".format(filename,
                                                         block_entry.size,
-                                                        width=width)
+                                                        width=width))
 
     def _hash(self, string, hash_type):
         """Hash a string using MPQ's hash function."""


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

`xrange()` was removed from Python on 1/1/2020.